### PR TITLE
remove mention of disclaimer

### DIFF
--- a/components/MailForm/DigestForm/index.tsx
+++ b/components/MailForm/DigestForm/index.tsx
@@ -142,7 +142,7 @@ export default function DigestForm({
                     Once you click <b>Submit</b>, Hoagie will append your
                     message in the upcoming weekly digest email.
                     This is sent to
-                    <b> all residential college listservs* on your behalf</b> (note NCW disclaimer).
+                    <b> all residential college listservs on your behalf</b>.
                     Your NetID will be included with your message regardless
                     of the content.
                 </Text>

--- a/components/MailForm/SendForm.tsx
+++ b/components/MailForm/SendForm.tsx
@@ -123,7 +123,7 @@ export default function Mail({
                 </Pane>
                 <Text>
                     Once you click <b>Send Email</b>, Hoagie will send the email to
-                    <b> all residential college listservs* on your behalf</b> (note NCW disclaimer).
+                    <b> all residential college listservs on your behalf</b>.
                     Your name and NetID will be included at the bottom of the email
                     regardless of the content.
                 </Text>


### PR DESCRIPTION
# Problem
The NCW listserv was added to Hoagie Mail in late January, but the warning messages for mail and digest both say to "note NCW disclaimer," causing confusion about whether Hoagie Mail was working for the NCW listserv.

# Solution
I removed the warning messages for mail and digest.

# Screenshots
### Before
<img width="558" alt="Screen Shot 2023-02-27 at 2 01 51 PM" src="https://user-images.githubusercontent.com/90424009/221678989-d73fa560-83ce-4978-b7d7-f5ecc0bb79f9.png">
<img width="483" alt="Screen Shot 2023-02-27 at 2 19 00 PM" src="https://user-images.githubusercontent.com/90424009/221679000-78a078bc-49fb-4a71-a96b-249c9f454303.png">

### After
<img width="491" alt="Screen Shot 2023-02-27 at 3 29 47 PM" src="https://user-images.githubusercontent.com/90424009/221679043-4cadf305-79b2-4e6a-b00e-533d80d7756b.png">
<img width="492" alt="Screen Shot 2023-02-27 at 3 30 46 PM" src="https://user-images.githubusercontent.com/90424009/221679055-578cee59-f309-4963-8555-9dc9c5d286cd.png">
